### PR TITLE
style(parser): apply ruff format to base.py

### DIFF
--- a/src/pyvider/hcl/parser/base.py
+++ b/src/pyvider/hcl/parser/base.py
@@ -19,6 +19,7 @@ from pyvider.hcl.parser.inference import auto_infer_cty_type
 
 def _cleanup_hcl_data(data: Any) -> Any:
     """Recursively clean up data from hcl2 (strip __is_block__ and unquote strings)."""
+
     def _clean_key(key: str) -> str:
         if len(key) >= 2 and key[0] == '"' and key[-1] == '"':
             return key[1:-1]


### PR DESCRIPTION
Follow-up to #2. The parser fix commit wasn't ruff-formatted, which fails the reusable's pre-release-tests format gate on release.yml runs. One-line format fix unblocks the v0.4.0 backfill.